### PR TITLE
fix: update genius stock config

### DIFF
--- a/Genius Stock.cfg
+++ b/Genius Stock.cfg
@@ -114,8 +114,8 @@ screw_thread: CW-M5
 [gcode_macro START_PRINT]
 # Reference https://github.com/KevinOConnor/klipper/blob/master/docs/Config_Reference.md#gcode_macroA
 # On how to override default parameters
-default_parameter_BED_TEMP: 60
-default_parameter_EXTRUDER_TEMP: 200	
+variable_bed_temp: 60
+variable_extruder_temp: 200	
 								 	
 gcode:
     # Home the printer


### PR DESCRIPTION
G-Code macro commands need to have the "variable_" prefix and may not contain upper case letters.